### PR TITLE
Update OpenCatalyst for weak-scale metric reporting

### DIFF
--- a/open_catalyst/configs/mlperf_hpc.yml
+++ b/open_catalyst/configs/mlperf_hpc.yml
@@ -17,6 +17,8 @@ task:
     mlperf_division: closed
     mlperf_status: onprem
     mlperf_platform: SUBMISSION_PLATFORM_PLACEHOLDER
+    mlperf_accelerators_per_node: 8
+    mlperf_accelerators_per_rank: 1
 
     dataset: trajectory_lmdb
     description: "Regressing to energies and forces for DFT trajectories from OCP"

--- a/open_catalyst/ocpmodels/trainers/mlperf_forces_trainer.py
+++ b/open_catalyst/ocpmodels/trainers/mlperf_forces_trainer.py
@@ -364,6 +364,7 @@ class MLPerfForcesTrainer(BaseTrainer):
             mllogger.event(key='accelerators_per_node', value=accelerators_per_node)
 
             # Log hyperparameters
+            mllogger.event(key=mllog.constants.SEED, value=self.config["cmd"]["seed"])
             mllogger.event(key=mllog.constants.GLOBAL_BATCH_SIZE,
                            value=self.config["optim"]["batch_size"] * self.config["gpus"])
             mllogger.event(key=mllog.constants.TRAIN_SAMPLES, value=len(self.train_loader.dataset))

--- a/open_catalyst/ocpmodels/trainers/mlperf_forces_trainer.py
+++ b/open_catalyst/ocpmodels/trainers/mlperf_forces_trainer.py
@@ -354,6 +354,15 @@ class MLPerfForcesTrainer(BaseTrainer):
             # Start mlperf initialization
             mllogger.start(key=mllog.constants.INIT_START)
 
+            # Weak-scaling HPC metrics
+            accelerators_per_node = self.config["task"]["mlperf_accelerators_per_node"]
+            accelerators_per_rank = self.config["task"]["mlperf_accelerators_per_rank"]
+            num_ranks = distutils.get_world_size()
+            num_nodes = (num_ranks * accelerators_per_rank) // accelerators_per_node
+            mllogger.event(key='number_of_ranks', value=num_ranks)
+            mllogger.event(key='number_of_nodes', value=num_nodes)
+            mllogger.event(key='accelerators_per_node', value=accelerators_per_node)
+
             # Log hyperparameters
             mllogger.event(key=mllog.constants.GLOBAL_BATCH_SIZE,
                            value=self.config["optim"]["batch_size"] * self.config["gpus"])


### PR DESCRIPTION
Updating to https://github.com/sparticlesteve/ocp/commit/102175ab71552db19f480c43603e5f8e85024a2b

This picks up the logging updates for weak-scale metrics reporting.

This reference code now requires to set `mlperf_accelerators_per_node` and `mlperf_accelerators_per_rank` in the config file.