### PR TITLE
rollback num_workers in DeepCam

### DIFF
--- a/deepcam/src/deepCam/train.py
+++ b/deepcam/src/deepCam/train.py
@@ -96,6 +96,7 @@ def main(pargs):
     
     # Logging hyperparameters
     logger.log_event(key = "global_batch_size", value = (pargs.local_batch_size * comm_size))
+    logger.log_event(key = "num_workers", value = comm_size)
     logger.log_event(key = "batchnorm_group_size", value = pargs.batchnorm_group_size)
     logger.log_event(key = "gradient_accumulation_frequency", value = pargs.gradient_accumulation_frequency)
     logger.log_event(key = "checkpoint", value = pargs.checkpoint)


### PR DESCRIPTION
Hi @sparticlesteve 
num_workers got deleted here: https://github.com/mlcommons/hpc/commit/f864f07ff82cfaffeb96127fc44b514c60dfb837#diff-966fcecb969dc11949fb713292dcd1629b59bd88bd48d10f5cc736c409fe1742L93

However, this is still needed by the branched checker.
Should we remove it from the compliance ymls and logging checker as well?

anyway, re-adding that line to the logs works...

Cheers!