### PR TITLE
[cosmoflow] Updates/fixes for v2.0 (shard+shuffle, software)

### DIFF
--- a/cosmoflow/builds/Dockerfile
+++ b/cosmoflow/builds/Dockerfile
@@ -1,8 +1,8 @@
-FROM nvcr.io/nvidia/tensorflow:21.03-tf2-py3
+FROM nvcr.io/nvidia/tensorflow:22.04-tf2-py3
 
 RUN python -m pip install --no-cache-dir -U pip
 
 RUN pip install --no-cache-dir pandas wandb
 
 # Install MLPerf-logging
-RUN pip install --no-cache-dir "git+https://github.com/mlperf-hpc/logging.git@hpc-0.5.0"
+RUN pip install --no-cache-dir "git+https://github.com/mlcommons/logging.git"

--- a/cosmoflow/data/__init__.py
+++ b/cosmoflow/data/__init__.py
@@ -29,6 +29,7 @@
 Keras dataset specifications.
 """
 
+
 def get_datasets(name, **data_args):
     if name == 'dummy':
         from .dummy import get_datasets

--- a/cosmoflow/data/cosmo.py
+++ b/cosmoflow/data/cosmo.py
@@ -111,9 +111,9 @@ def construct_dataset(file_dir, n_samples, batch_size, n_epochs,
 
     # Define the dataset from the list of sharded, shuffled files
     data = tf.data.Dataset.from_tensor_slices(filenames)
-    data = data.shard(num_shards=n_shards, index=shard)
     if shuffle:
         data = data.shuffle(len(filenames), reshuffle_each_iteration=True)
+    data = data.shard(num_shards=n_shards, index=shard)
 
     # Parse TFRecords
     parse_data = partial(_parse_data, shape=sample_shape, apply_log=apply_log)

--- a/cosmoflow/data/cosmo.py
+++ b/cosmoflow/data/cosmo.py
@@ -47,6 +47,7 @@ except ImportError:
 import utils.distributed
 from utils.staging import stage_files
 
+
 def _parse_data(sample_proto, shape, apply_log=False):
     """Parse the data out of the TFRecord proto buf.
 
@@ -74,6 +75,7 @@ def _parse_data(sample_proto, shape, apply_log=False):
         x /= (tf.reduce_sum(x) / np.prod(shape))
 
     return x, y
+
 
 def construct_dataset(file_dir, n_samples, batch_size, n_epochs,
                       sample_shape, samples_per_file=1, n_file_sets=1,
@@ -138,6 +140,7 @@ def construct_dataset(file_dir, n_samples, batch_size, n_epochs,
 
     # Prefetch to device
     return data.prefetch(prefetch), n_steps
+
 
 def get_datasets(data_dir, sample_shape, n_train, n_valid,
                  batch_size, n_epochs, dist, samples_per_file=1,

--- a/cosmoflow/data/dummy.py
+++ b/cosmoflow/data/dummy.py
@@ -29,9 +29,6 @@
 Random dummy dataset specification.
 """
 
-# System
-import math
-
 # Externals
 import tensorflow as tf
 
@@ -42,6 +39,7 @@ def construct_dataset(sample_shape, target_shape,
     y = tf.random.uniform([n_samples]+target_shape)
     data = tf.data.Dataset.from_tensor_slices((x, y))
     return data.repeat().batch(batch_size).prefetch(4)
+
 
 def get_datasets(sample_shape, target_shape, batch_size,
                  n_train, n_valid, dist, n_epochs=None, shard=False):

--- a/cosmoflow/models/cosmoflow.py
+++ b/cosmoflow/models/cosmoflow.py
@@ -39,6 +39,7 @@ except ImportError:
 
 from .layers import scale_1p2
 
+
 def build_model(input_shape, target_size,
                 conv_size=32, kernel_size=3, n_conv_layers=5,
                 fc1_size=128, fc2_size=64, l2=0,

--- a/cosmoflow/train.py
+++ b/cosmoflow/train.py
@@ -382,9 +382,9 @@ def main():
         print_training_summary(config['output_dir'], args.print_fom)
 
     # Print GPU memory
-    if gpu is not None:
-        gpu_mem_info = tf.config.experimental.get_memory_info(f'GPU:{gpu}')
-        logging.info('Peak GPU memory: %.2f GB', gpu_mem_info['peak'] / 1024 / 1024 / 1024)
+    #if gpu is not None:
+    #    gpu_mem_info = tf.config.experimental.get_memory_info(f'GPU:{gpu}')
+    #    logging.info('Peak GPU memory: %.2f GB', gpu_mem_info['peak'] / 1024 / 1024 / 1024)
 
     # Finalize
     if dist.rank == 0:

--- a/cosmoflow/train.py
+++ b/cosmoflow/train.py
@@ -118,14 +118,11 @@ def parse_args():
     add_arg('--amp', action='store_true', help='Enable automatic mixed precision')
 
     # Other settings
-    add_arg('--mlperf', action='store_true',
-            help='Enable MLPerf logging')
-    add_arg('--wandb', action='store_true',
-            help='Enable W&B logging')
-    add_arg('--tensorboard', action='store_true',
-            help='Enable TB logger')
-    add_arg('--print-fom', action='store_true',
-            help='Print parsable figure of merit')
+    add_arg('--seed', type=int, default=0, help='Specify the random seed')
+    add_arg('--mlperf', action='store_true', help='Enable MLPerf logging')
+    add_arg('--wandb', action='store_true', help='Enable W&B logging')
+    add_arg('--tensorboard', action='store_true', help='Enable TB logger')
+    add_arg('--print-fom', action='store_true', help='Print parsable figure of merit')
     add_arg('-v', '--verbose', action='store_true')
     return parser.parse_args()
 
@@ -226,6 +223,10 @@ def main():
                  dist.rank, dist.size, dist.local_rank, dist.local_size)
     if dist.rank == 0:
         logging.info('Configuration: %s', config)
+
+    # Random seeding
+    tf.random.set_seed(args.seed)
+    np.random.seed(args.seed)
 
     # Setup MLPerf logging
     if args.mlperf:

--- a/cosmoflow/utils/argparse.py
+++ b/cosmoflow/utils/argparse.py
@@ -30,14 +30,6 @@
 import argparse
 import yaml
 
-#class StoreDictKeyPair(argparse.Action):
-#    """An action for reading key-value pairs from command line"""
-#    def __call__(self, parser, namespace, values, option_string=None):
-#        my_dict = {}
-#        for kv in values.split(","):
-#            k,v = kv.split("=")
-#            my_dict[k] = v
-#        setattr(namespace, self.dest, my_dict)
 
 class ReadYaml(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):

--- a/cosmoflow/utils/callbacks.py
+++ b/cosmoflow/utils/callbacks.py
@@ -41,6 +41,7 @@ try:
 except ImportError:
     have_mlperf_logging = False
 
+
 class MLPerfLoggingCallback(tf.keras.callbacks.Callback):
     """A Keras Callback for logging MLPerf results"""
     def __init__(self, metric='val_mean_absolute_error', log_key='eval_error'):
@@ -68,6 +69,7 @@ class MLPerfLoggingCallback(tf.keras.callbacks.Callback):
         self.mllogger.event(key=self.log_key, value=eval_metric,
                             metadata={'epoch_num': epoch + 1})
 
+
 class StopAtTargetCallback(tf.keras.callbacks.Callback):
     """A Keras callback for stopping training at specified target quality"""
 
@@ -80,6 +82,7 @@ class StopAtTargetCallback(tf.keras.callbacks.Callback):
         if self.target_max is not None and eval_metric <= self.target_max:
             self.model.stop_training = True
             logging.info('Target reached; stopping training')
+
 
 class TimingCallback(tf.keras.callbacks.Callback):
     """A Keras Callback which records the time of each epoch"""

--- a/cosmoflow/utils/device.py
+++ b/cosmoflow/utils/device.py
@@ -40,6 +40,7 @@ import tensorflow as tf
 # Locals
 import utils.distributed as dist
 
+
 def configure_session(gpu=None, intra_threads=None, inter_threads=None,
                       kmp_blocktime=None, kmp_affinity=None, omp_num_threads=None):
     """Sets the thread knobs in the TF backend"""

--- a/cosmoflow/utils/distributed.py
+++ b/cosmoflow/utils/distributed.py
@@ -29,11 +29,13 @@
 
 import horovod.tensorflow.keras as hvd
 
+
 def rank():
     try:
         return hvd.rank()
     except ValueError:
         return 0
+
 
 def barrier():
     try:

--- a/cosmoflow/utils/mlperf_logging.py
+++ b/cosmoflow/utils/mlperf_logging.py
@@ -41,12 +41,14 @@ try:
 except ImportError:
     have_mlperf_logging = False
 
+
 def configure_mllogger(log_dir):
     """Setup the MLPerf logger"""
     if not have_mlperf_logging:
         raise RuntimeError('mlperf_logging package unavailable')
     mllog.config(filename=os.path.join(log_dir, 'mlperf.log'))
     return mllog.get_mllogger()
+
 
 def log_submission_info(benchmark='cosmoflow',
                         org='UNDEFINED',

--- a/cosmoflow/utils/optimizers.py
+++ b/cosmoflow/utils/optimizers.py
@@ -45,6 +45,7 @@ except ImportError:
 # Locals
 import utils.distributed
 
+
 def _lr_schedule(epoch, base_lr, peak_lr, n_warmup_epochs, decay_schedule={}):
     """Learning rate schedule function.
 
@@ -66,6 +67,7 @@ def _lr_schedule(epoch, base_lr, peak_lr, n_warmup_epochs, decay_schedule={}):
             if e >= decay_epoch and e < epoch:
                 decay_epoch, decay_factor = e, d
         return peak_lr * decay_factor
+
 
 def get_lr_schedule(base_lr, global_batch_size, base_batch_size=None,
                     scaling=None, n_warmup_epochs=0, decay_schedule={}):
@@ -96,6 +98,7 @@ def get_lr_schedule(base_lr, global_batch_size, base_batch_size=None,
     return partial(_lr_schedule, base_lr=base_lr, peak_lr=peak_lr,
                    n_warmup_epochs=n_warmup_epochs,
                    decay_schedule=decay_schedule)
+
 
 def get_optimizer(name, distributed=False, **opt_args):
     """Configure the optimizer"""

--- a/cosmoflow/utils/staging.py
+++ b/cosmoflow/utils/staging.py
@@ -32,6 +32,7 @@ import os
 import shutil
 import logging
 
+
 def stage_files(input_dir, output_dir, n_files, rank=0, size=1):
     """Stage specified number of files to directory.
 


### PR DESCRIPTION
Pulls changes from https://github.com/sparticlesteve/cosmoflow-benchmark/pull/44
- Adding random seed setting: currently setting both TF and numpy random
  generators with the same seed provided via command line. Default seed
  is zero.
- Swap order of shard and shuffle in dataset

https://github.com/sparticlesteve/cosmoflow-benchmark/pull/45
- Better keras function for setting all random seeds
- MLPerf logging of random seed
- Optional command line switch for "enabling deterministic ops" in TF

https://github.com/sparticlesteve/cosmoflow-benchmark/pull/46
- Code cleanups
- Minor TF API updates

https://github.com/sparticlesteve/cosmoflow-benchmark/pull/47
- Update dockerfile and latest image to use NGC 22.04