### PR TITLE
[DeepCAM] remove link to old github repository

### DIFF
--- a/deepcam/README.md
+++ b/deepcam/README.md
@@ -1,8 +1,7 @@
 # Deep Learning Climate Segmentation Benchmark
 
 PyTorch implementation for the climate segmentation benchmark, based on the
-Exascale Deep Learning for Climate Analytics codebase here:
-https://github.com/azrael417/ClimDeepLearn, and the paper:
+Exascale Deep Learning for Climate Analytics paper:
 https://arxiv.org/abs/1810.01993
 
 ## Dataset


### PR DESCRIPTION
removed link to thorsten's old code repository at the top of the DeepCAM README which could cause some confusion and is probably not the most important thing anyway.