### PR TITLE
[deepcam] switch to SLURM_PROCID in deepcam nccl-slurm

### DIFF
--- a/deepcam/src/deepCam/utils/comm.py
+++ b/deepcam/src/deepCam/utils/comm.py
@@ -94,7 +94,7 @@ def init(method, batchnorm_group_size=1):
                                 world_size = world_size)
         
     elif method == "nccl-slurm":
-        rank = int(os.getenv("PMIX_RANK"))
+        rank = int(os.getenv("SLURM_PROCID"))
         world_size = int(os.getenv("SLURM_NTASKS"))
         address = os.getenv("SLURM_LAUNCH_NODE_IPADDR")
         port = "29500"


### PR DESCRIPTION
This changes utils.comm.init to use SLURM_PROCID instead of PMIX_RANK
for nccl-slurm setup. The latter is not always set in slurm jobs.