### PR TITLE
fix ddp device_ids for cpu only

### DIFF
--- a/deepcam/src/deepCam/train.py
+++ b/deepcam/src/deepCam/train.py
@@ -164,7 +164,7 @@ def main(pargs):
         bucket_cap_mb = 220
     
     # get stream, relevant for graph capture
-    ddp_net = DDP(net, device_ids=[device.index],
+    ddp_net = DDP(net, device_ids=([device.index] if device.index else None),
                   output_device=device.index,
                   find_unused_parameters=False,
                   broadcast_buffers=False,


### PR DESCRIPTION
Sets DDP device_ids to None if not using GPUs, which enables running on CPU.